### PR TITLE
Allow empty strings in applications

### DIFF
--- a/src/api/applications/controllers/post-application.js
+++ b/src/api/applications/controllers/post-application.js
@@ -9,16 +9,17 @@ export const postApplicationController = {
     validate: {
       query: false,
       payload: joi.object({
-        title: joi.string().required(),
-        background: joi.string().required(),
-        firstName: joi.string().required(),
-        lastName: joi.string().required(),
+        title: joi.string().required().allow(''),
+        background: joi.string().required().allow(''),
+        firstName: joi.string().required().allow(''),
+        lastName: joi.string().required().allow(''),
         email: joi
           .string()
           .required()
-          .email({ tlds: { allow: false } }),
-        site: joi.string(),
-        address: joi.string()
+          .email({ tlds: { allow: false } })
+          .allow(''),
+        site: joi.string().allow(''),
+        address: joi.string().allow('')
       })
     }
   },

--- a/src/api/applications/controllers/post-application.test.js
+++ b/src/api/applications/controllers/post-application.test.js
@@ -65,3 +65,35 @@ describe('POST /applications', () => {
     )
   })
 })
+
+describe('POST /applications validation', () => {
+  const payloadValidator = postApplicationController.options.validate.payload
+
+  it('should fail if fields are missing', () => {
+    const result = payloadValidator.validate({
+      title: '',
+      background: '',
+      // firstName: '', // missing field
+      lastName: '',
+      email: '',
+      site: '',
+      address: ''
+    })
+
+    expect(result.error.message).toContain('"firstName" is required')
+  })
+
+  it('should succeed if fields are empty strings', () => {
+    const result = payloadValidator.validate({
+      title: '',
+      background: '',
+      firstName: '',
+      lastName: '',
+      email: '',
+      site: '',
+      address: ''
+    })
+
+    expect(result.error).toBeUndefined()
+  })
+})


### PR DESCRIPTION
The frontend has no good way to show users why their submissions are being rejected, and we shouldn't do that during prototyping IMO.

It's great to get an error when the API expected by /applications misaligns with the frontend - flushes out bugs early.  But for prototyping, empty inputs are fine IMO.