### PR TITLE
Add drop-database endpoint

### DIFF
--- a/src/api/admin/controllers/drop-database.js
+++ b/src/api/admin/controllers/drop-database.js
@@ -4,6 +4,10 @@ export const dropDatabaseController = {
 
     await db.collection('applications').deleteMany({})
     await db.collection('counters').deleteMany({})
+    await db.collection('counters').insertOne({
+      name: 'applicationId',
+      counter: 1
+    })
 
     return h.response({ message: 'success' }).code(200)
   }

--- a/src/api/admin/controllers/drop-database.js
+++ b/src/api/admin/controllers/drop-database.js
@@ -1,0 +1,10 @@
+export const dropDatabaseController = {
+  handler: async (request, h) => {
+    const { db } = request
+
+    await db.collection('applications').deleteMany({})
+    await db.collection('counters').deleteMany({})
+
+    return h.response({ message: 'success' }).code(200)
+  }
+}

--- a/src/api/admin/controllers/drop-database.test.js
+++ b/src/api/admin/controllers/drop-database.test.js
@@ -21,6 +21,9 @@ describe('POST /admin/drop-database', () => {
 
     expect(await mockMongo.collection('applications').count()).toEqual(0)
 
-    expect(await mockMongo.collection('counters').count()).toEqual(0)
+    expect(await mockMongo.collection('counters').findOne({})).toMatchObject({
+      name: 'applicationId',
+      counter: 1
+    })
   })
 })

--- a/src/api/admin/controllers/drop-database.test.js
+++ b/src/api/admin/controllers/drop-database.test.js
@@ -1,0 +1,26 @@
+import { dropDatabaseController } from '~/src/api/admin/controllers/drop-database'
+
+describe('POST /admin/drop-database', () => {
+  test('should drop the mongo db applications and counters', async () => {
+    const { mockMongo, mockHandler } = global
+
+    const payload = {}
+
+    await dropDatabaseController.handler(
+      {
+        db: mockMongo,
+        payload
+      },
+      mockHandler
+    )
+
+    expect(mockHandler.code).toHaveBeenCalledWith(200)
+    expect(mockHandler.response).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'success' })
+    )
+
+    expect(await mockMongo.collection('applications').count()).toEqual(0)
+
+    expect(await mockMongo.collection('counters').count()).toEqual(0)
+  })
+})

--- a/src/api/admin/index.js
+++ b/src/api/admin/index.js
@@ -1,6 +1,6 @@
 import { dropDatabaseController } from '~/src/api/admin/controllers/drop-database'
 
-export const applications = {
+export const admin = {
   plugin: {
     name: 'admin',
     register: async (server) => {

--- a/src/api/admin/index.js
+++ b/src/api/admin/index.js
@@ -1,0 +1,16 @@
+import { dropDatabaseController } from '~/src/api/admin/controllers/drop-database'
+
+export const applications = {
+  plugin: {
+    name: 'admin',
+    register: async (server) => {
+      server.route([
+        {
+          method: 'POST',
+          path: '/admin/drop-database',
+          ...dropDatabaseController
+        }
+      ])
+    }
+  }
+}

--- a/src/api/router.js
+++ b/src/api/router.js
@@ -1,11 +1,12 @@
 import { applications } from '~/src/api/applications'
+import { admin } from '~/src/api/admin'
 import { health } from '~/src/api/health'
 
 const router = {
   plugin: {
     name: 'Router',
     register: async (server) => {
-      await server.register([applications, health])
+      await server.register([applications, admin, health])
     }
   }
 }


### PR DESCRIPTION
During testing, we don't want to have to migrate case data continually. We don't have direct db access in CDP dev, so we'll need a page on the frontend to do so.

This API could be used to power that page.